### PR TITLE
Use DefaultSSLWebSocketClientFactory for wss

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/WebSocketsConnectionProvider.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/WebSocketsConnectionProvider.java
@@ -3,6 +3,7 @@ package ua.naiksoftware.stomp;
 import android.util.Log;
 
 import org.java_websocket.WebSocket;
+import org.java_websocket.client.DefaultSSLWebSocketClientFactory;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft_17;
 import org.java_websocket.exceptions.InvalidDataException;
@@ -16,6 +17,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
+import javax.net.ssl.SSLContext;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -107,6 +110,17 @@ public class WebSocketsConnectionProvider implements ConnectionProvider {
                 emitLifecycleEvent(new LifecycleEvent(LifecycleEvent.Type.ERROR, ex));
             }
         };
+
+        if(mUri.startsWith("wss")) {
+            try {
+                SSLContext sc = SSLContext.getInstance("TLS");
+                sc.init(null, null, null);
+                mWebSocketClient.setWebSocketFactory(new DefaultSSLWebSocketClientFactory(sc));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
         mWebSocketClient.connect();
         haveConnection = true;
     }


### PR DESCRIPTION
wss connection was being immediately closed.

So, I followed the tutorial at: 
http://www.juliankrone.com/connect-and-transfer-data-with-secure-websockets-in-android/

and made this change.

Currently, wss is working for me with:
Tomcat 8.5.5's NIO connector

That's the only container/connector I have tested this with!