### PR TITLE
Issue #40 - Unsubscribing a list of subscriptions causes ConcurrentModificationException

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
@@ -15,7 +15,6 @@ import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.observables.ConnectableObservable;
-import rx.schedulers.Schedulers;
 import ua.naiksoftware.stomp.ConnectionProvider;
 import ua.naiksoftware.stomp.LifecycleEvent;
 import ua.naiksoftware.stomp.StompHeader;
@@ -171,18 +170,21 @@ public class StompClient {
            subscribersSet.add(subscriber);
 
        }).doOnUnsubscribe(() -> {
+           Set<String> destSet = new HashSet<String>();
            for (String dest : mSubscribers.keySet()) {
                Set<Subscriber<? super StompMessage>> set = mSubscribers.get(dest);
                for (Subscriber<? super StompMessage> subscriber : set) {
                    if (subscriber.isUnsubscribed()) {
                        set.remove(subscriber);
                        if (set.size() < 1) {
-                           mSubscribers.remove(dest);
+                           destSet.add(dest);
                            unsubscribePath(dest).subscribe();
                        }
                    }
                }
            }
+           for (String dest : destSet)
+               mSubscribers.remove(dest);
        });
    }
 

--- a/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -170,21 +171,22 @@ public class StompClient {
            subscribersSet.add(subscriber);
 
        }).doOnUnsubscribe(() -> {
-           Set<String> destSet = new HashSet<String>();
-           for (String dest : mSubscribers.keySet()) {
-               Set<Subscriber<? super StompMessage>> set = mSubscribers.get(dest);
-               for (Subscriber<? super StompMessage> subscriber : set) {
+           Iterator<String> mapIterator = mSubscribers.keySet().iterator();
+           while (mapIterator.hasNext()) {
+               String destinationUrl = mapIterator.next();
+               Set<Subscriber<? super StompMessage>> set = mSubscribers.get(destinationUrl);
+               Iterator<Subscriber<? super StompMessage>> setIterator = set.iterator();
+               while (setIterator.hasNext()) {
+                   Subscriber<? super StompMessage> subscriber = setIterator.next();
                    if (subscriber.isUnsubscribed()) {
-                       set.remove(subscriber);
+                       setIterator.remove();
                        if (set.size() < 1) {
-                           destSet.add(dest);
-                           unsubscribePath(dest).subscribe();
+                           mapIterator.remove();
+                           unsubscribePath(destinationUrl).subscribe();
                        }
                    }
                }
            }
-           for (String dest : destSet)
-               mSubscribers.remove(dest);
        });
    }
 


### PR DESCRIPTION
If you keep a List or a Map of Subscription's, and you want to unsubscribe all of those Subscriptions in one iteration, then a ConcurrentModificationException is thrown.  

I found this issue because one of my Fragments is subscribed to many topics that are not needed by any other Fragment in my app.  I'd like to unsubscribe those topics at one time in my Fragment onDestroyView() method.  The only other way I can think of doing this would be to have a separate Subscription object for every topic the Fragment wants to subscribe to, but that doesn't scale very well.

