### PR TITLE
Both Websocket and OkHttp must be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ At now supported connection providers:
 - `org.java_websocket.WebSocket.class` ('org.java-websocket:Java-WebSocket:1.3.0')
 - `okhttp3.WebSocket.class` ('com.squareup.okhttp3:okhttp:3.8.0')
 
+You must include both of these in your Gradle dependencies:
+``` gradle
+compile 'org.java-websocket:java-websocket:1.3.0'
+compile 'com.squareup.okhttp3:okhttp:3.8.0'
+```
+
 You can add own connection provider. Just implement interface `ConnectionProvider`.
 If you implement new provider, please create pull request :)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ repositories {
 }
 dependencies {
     compile 'com.github.NaikSoftware:StompProtocolAndroid:{latest version}'
+    compile 'org.java-websocket:java-websocket:1.3.0'
+    compile 'com.squareup.okhttp3:okhttp:3.8.0'
 }
 ```
 


### PR DESCRIPTION
It should be mentioned that, for v1.3.1 to work, the project depending on it must include both Java-Websocket and OkHttp in its Gradle dependencies.