### PR TITLE
Handle the connect lifecycle disposable

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
@@ -33,6 +33,7 @@ public class StompClient {
     public static final String DEFAULT_ACK = "auto";
 
     private Disposable mMessagesDisposable;
+    private Disposable mLifecycleDisposable;
     private Map<String, Set<FlowableEmitter<? super StompMessage>>> mEmitters = new HashMap<>();
     private List<ConnectableFlowable<Void>> mWaitConnectionFlowables;
     private final ConnectionProvider mConnectionProvider;
@@ -73,7 +74,7 @@ public class StompClient {
     public void connect(List<StompHeader> _headers, boolean reconnect) {
         if (reconnect) disconnect();
         if (mConnected) return;
-        mConnectionProvider.getLifecycleReceiver()
+        mLifecycleDisposable = mConnectionProvider.getLifecycleReceiver()
                 .subscribe(lifecycleEvent -> {
                     switch (lifecycleEvent.getType()) {
                         case OPENED:
@@ -155,6 +156,7 @@ public class StompClient {
 
     public void disconnect() {
         if (mMessagesDisposable != null) mMessagesDisposable.dispose();
+        if (mLifecycleDisposable != null) mLifecycleDisposable.dispose();
         mConnected = false;
     }
 


### PR DESCRIPTION
I noticed when you connect and disconnect from the stomp client in a bound service (such as on multiple activity rotation) the subscription threads for the connect method lifecycle receiver weren't being cleaned up.