### PR TITLE
concurrenthashmap

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.reactivex.BackpressureStrategy;
@@ -33,7 +34,7 @@ public class StompClient {
     public static final String DEFAULT_ACK = "auto";
 
     private Disposable mMessagesDisposable;
-    private Map<String, Set<FlowableEmitter<? super StompMessage>>> mEmitters = new HashMap<>();
+    private Map<String, Set<FlowableEmitter<? super StompMessage>>> mEmitters = new ConcurrentHashMap<>();
     private List<ConnectableFlowable<Void>> mWaitConnectionFlowables;
     private final ConnectionProvider mConnectionProvider;
     private HashMap<String, String> mTopics;


### PR DESCRIPTION
We got this exception a far bit when restarting our app or rotating that caused the activity to be destroyed and recreated and we have a bunch of topic subscriptions disposed onPause and recreated on onResume

```
FATAL EXCEPTION: Thread-5
                                                                   Process: co.oroson.android, PID: 18456
                                                                   io.reactivex.exceptions.OnErrorNotImplementedException
                                                                       at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:704)
                                                                       at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:701)
                                                                       at io.reactivex.internal.subscribers.LambdaSubscriber.onError(LambdaSubscriber.java:76)
                                                                       at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:66)
                                                                       at io.reactivex.internal.operators.flowable.FlowableMap$MapSubscriber.onNext(FlowableMap.java:69)
                                                                       at io.reactivex.internal.operators.flowable.FlowableDoOnLifecycle$SubscriptionLambdaSubscriber.onNext(FlowableDoOnLifecycle.java:79)
                                                                       at io.reactivex.internal.operators.flowable.FlowableCreate$BufferAsyncEmitter.drain(FlowableCreate.java:542)
                                                                       at io.reactivex.internal.operators.flowable.FlowableCreate$BufferAsyncEmitter.onNext(FlowableCreate.java:466)
                                                                       at ua.naiksoftware.stomp.WebSocketsConnectionProvider.emitMessage(WebSocketsConnectionProvider.java:161)
                                                                       at ua.naiksoftware.stomp.WebSocketsConnectionProvider.access$300(WebSocketsConnectionProvider.java:30)
                                                                       at ua.naiksoftware.stomp.WebSocketsConnectionProvider$1.onMessage(WebSocketsConnectionProvider.java:104)
                                                                       at org.java_websocket.client.WebSocketClient.onWebsocketMessage(WebSocketClient.java:292)
                                                                       at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:417)
                                                                       at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:170)
                                                                       at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:229)
                                                                       at java.lang.Thread.run(Thread.java:761)
                                                                    Caused by: java.util.ConcurrentModificationException
                                                                       at java.util.HashMap$HashIterator.nextEntry(HashMap.java:851)
                                                                       at java.util.HashMap$KeyIterator.next(HashMap.java:885)
                                                                       at ua.naiksoftware.stomp.client.StompClient.callSubscribers(StompClient.java:144)
                                                                       at ua.naiksoftware.stomp.client.StompClient.lambda$connect$1(StompClient.java:113)
                                                                       at ua.naiksoftware.stomp.client.StompClient$$Lambda$5.accept(Unknown Source)
                                                                       at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:62)
                                                                       at io.reactivex.internal.operators.flowable.FlowableMap$MapSubscriber.onNext(FlowableMap.java:69) 
                                                                       at io.reactivex.internal.operators.flowable.FlowableDoOnLifecycle$SubscriptionLambdaSubscriber.onNext(FlowableDoOnLifecycle.java:79) 
                                                                       at io.reactivex.internal.operators.flowable.FlowableCreate$BufferAsyncEmitter.drain(FlowableCreate.java:542) 
                                                                       at io.reactivex.internal.operators.flowable.FlowableCreate$BufferAsyncEmitter.onNext(FlowableCreate.java:466) 
                                                                       at ua.naiksoftware.stomp.WebSocketsConnectionProvider.emitMessage(WebSocketsConnectionProvider.java:161) 
                                                                       at ua.naiksoftware.stomp.WebSocketsConnectionProvider.access$300(WebSocketsConnectionProvider.java:30) 
                                                                       at ua.naiksoftware.stomp.WebSocketsConnectionProvider$1.onMessage(WebSocketsConnectionProvider.java:104) 
                                                                       at org.java_websocket.client.WebSocketClient.onWebsocketMessage(WebSocketClient.java:292) 
                                                                       at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:417) 
                                                                       at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:170) 
                                                                       at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:229) 
                                                                       at java.lang.Thread.run(Thread.java:761)
```