### PR TITLE
OKHttp no handling of a closing connection

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/OkHttpConnectionProvider.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/OkHttpConnectionProvider.java
@@ -106,6 +106,11 @@ import okio.ByteString;
                     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
                         emitLifecycleEvent(new LifecycleEvent(LifecycleEvent.Type.ERROR, new Exception(t)));
                     }
+                    
+                    @Override
+                    public void onClosing(final WebSocket webSocket, final int code, final String reason) {
+                        webSocket.close(code, reason);
+                    }
                 }
 
         );


### PR DESCRIPTION
If we connect to a WS server and the WS server then goes down we don't get a CLOSED lifecycle event from our stomp client. We should handle OKHttp web socket listener onClosing method.