### PR TITLE
handle server error message

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/dto/StompCommand.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/dto/StompCommand.java
@@ -11,6 +11,7 @@ public class StompCommand {
     public static final String MESSAGE = "MESSAGE";
     public static final String SUBSCRIBE = "SUBSCRIBE";
     public static final String UNSUBSCRIBE = "UNSUBSCRIBE";
+    public static final String ERROR = "ERROR";
 
     public static final String UNKNOWN = "UNKNOWN";
 }

--- a/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
@@ -17,7 +17,7 @@ public class StompMessage {
 
     public static final String TERMINATE_MESSAGE_SYMBOL = "\u0000";
 
-    private static final Pattern PATTERN_HEADER = Pattern.compile("([^:\\s]+)\\s*:\\s*([^:\\s]+)");
+    private static final Pattern PATTERN_HEADER = Pattern.compile("([^:\\s]+)\\s*:\\s*(.*)");
 
     private final String mStompCommand;
     private final List<StompHeader> mStompHeaders;


### PR DESCRIPTION
- handle server's 'error message' 
- improves stomp header regexp because it can not parse "message: {\'key\':\'value\'}"