### PR TITLE
Handled/Prevented the crash caused by an OnErrorNotImplementedException

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/StompClient.java
@@ -143,6 +143,8 @@ public class StompClient {
                 .filter(msg -> msg.getStompCommand().equals(StompCommand.CONNECTED))
                 .subscribe(stompMessage -> {
                     getConnectionStream().onNext(true);
+                }, onError -> {
+                    Log.e(TAG, "Error parsing message", onError);
                 });
     }
 


### PR DESCRIPTION
Handled/Prevented the crash caused by an OnErrorNotImplementedException which itself was caused by a NoSuchElementException thrown when parsing stomp messages.

This was a crash experienced by a few people who filed and commented on issues, including myself. There doesn't seem to be any connection between messages that cause the crash other than that they are generally 'Disconnecting due to error' messages, however, the crash always occurs on the same line.

I chose to implement an onError rather than wrapping the erroneous line in a try-catch will continue execution even though the scanner is not where it is expected to be in the following code, and it will return an incorrectly parsed StompMessage which could lead further errors down the line. 

Thanks