### PR TITLE
Changed header pattern

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -29,7 +29,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -29,7 +29,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
@@ -17,7 +17,7 @@ public class StompMessage {
 
     public static final String TERMINATE_MESSAGE_SYMBOL = "\u0000";
 
-    private static final Pattern PATTERN_HEADER = Pattern.compile("([^:\\s]+)\\s*:\\s*([^:\\s]+)");
+    private static final Pattern PATTERN_HEADER = Pattern.compile("([^:\\s]+)\\s*:\\s*([^\\n]+)");
 
     private final String mStompCommand;
     private final List<StompHeader> mStompHeaders;


### PR DESCRIPTION
According to the [STOMP protocol specification 1.2](https://stomp.github.io/stomp-specification-1.2.html#STOMP_Frames); each header should be terminated with an EOL. Currently, the regex for headers stops if it sees a `:`. This pull request fixes the regex.

An example of a message that the current implementation can't handle is shown below:

```
ERROR
message:Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]; nested exception is org.springframework.security.access.AccessDeniedException\c Access is denied
content-length:0

 
```