### PR TITLE
Fix issue with missed lifecycle state

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/StompClient.java
@@ -126,6 +126,7 @@ public class StompClient {
 
                         case CLOSED:
                             Log.d(TAG, "Socket closed");
+                            lifecyclePublishSubject.onNext(lifecycleEvent);
                             disconnect();
                             break;
 


### PR DESCRIPTION
Lifecycle state "Closed" has never been published to the lifecyclePublishSubject.