### PR TITLE
Update HeartBeatTask.java

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/HeartBeatTask.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/HeartBeatTask.java
@@ -140,7 +140,7 @@ public class HeartBeatTask {
         if (serverHeartbeat > 0) {
             final long now = System.currentTimeMillis();
             //use a forgiving boundary as some heart beats can be delayed or lost.
-            final long boundary = now - (3 * serverHeartbeat);
+            final long boundary = now - (1 * serverHeartbeat);
             //we need to check because the task could failed to abort
             if (lastServerHeartBeat < boundary) {
                 Log.d(TAG, "It's a sad day ;( Server didn't send heart-beat on time. Last received at '" + lastServerHeartBeat + "' and now is '" + now + "'");
@@ -149,8 +149,8 @@ public class HeartBeatTask {
                 }
             } else {
                 Log.d(TAG, "We were checking and server sent heart-beat on time. So well-behaved :)");
-                lastServerHeartBeat = System.currentTimeMillis();
             }
+            this.scheduleServerHeartBeatCheck();
         }
     }
 


### PR DESCRIPTION
Fixed heartbeat failed not working and default no boundary.

```
        switch (lifecycleEvent.getType()) {
            case FAILED_SERVER_HEARTBEAT:

                if(failed_heartbeat_times.incrementAndGet() >= 3) {
                    toast("Stomp failed server heartbeat");
                    ...
                }

            break;
        }
```
